### PR TITLE
fix(auth): backfill `IdentityEndpoint` from `clouds.yaml` when `cloud` is set

### DIFF
--- a/auth/config.go
+++ b/auth/config.go
@@ -134,6 +134,10 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 			v := (!*cloud.Verify)
 			c.Insecure = &v
 		}
+
+		if c.IdentityEndpoint == "" && cloud.AuthInfo != nil && cloud.AuthInfo.AuthURL != "" {
+			c.IdentityEndpoint = cloud.AuthInfo.AuthURL
+		}
 	} else {
 		authInfo := &clientconfig.AuthInfo{
 			AuthURL:                     c.IdentityEndpoint,
@@ -166,6 +170,11 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	ao, err := clientconfig.AuthOptions(clientOpts)
 	if err != nil {
 		return err
+	}
+
+	// if AuthOptions didnt resolve an endpoint but clouds.yaml had one
+	if ao.IdentityEndpoint == "" && c.IdentityEndpoint != "" {
+		ao.IdentityEndpoint = c.IdentityEndpoint
 	}
 
 	log.Printf("[DEBUG] OpenStack allowReauth: %t", c.AllowReauth)

--- a/auth/config_test.go
+++ b/auth/config_test.go
@@ -1,0 +1,42 @@
+package auth_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/terraform-provider-openstack/utils/v2/auth"
+)
+
+func TestCloudsYAMLBackfillsAuthURL(t *testing.T) {
+	dir := t.TempDir()
+	yaml := `
+clouds:
+  foo:
+    auth:
+      auth_url: https://keystone.example/v3
+      token: dummy-token
+    region_name: RegionOne
+`
+	path := filepath.Join(dir, "clouds.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write clouds.yaml: %v", err)
+	}
+
+	t.Setenv("OS_CLIENT_CONFIG_FILE", path)
+	t.Setenv("OS_AUTH_URL", "") // keep env empty
+
+	cfg := &auth.Config{
+		Cloud: "foo",
+		// IdentityEndpoint is omitted to trigger backfill
+	}
+
+	_ = cfg.LoadAndValidate(context.Background())
+
+	got := cfg.IdentityEndpoint
+	want := "https://keystone.example/v3"
+	if got != want {
+		t.Fatalf("expected IdentityEndpoint %q from clouds.yaml, got %q", want, got)
+	}
+}


### PR DESCRIPTION
When `cloud` is set and the provider block omits `auth_url`, `LoadAndValidate` does not populate the identity endpoint from `clouds.yaml`. Users must export `OS_AUTH_URL` even though `auth.auth_url` exists in `clouds.yaml`.

 Basically this PR only fills IdentityEdpoint when empty and ensures the final AuthOptions carries it. 

Also added a unit tests for the backfill